### PR TITLE
fix some build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ powershell
 Set-ExecutionPolicy unrestricted
 ```
 
+#### If build with PowerShell does not work
+If you get errors like "Error: Java heap space" or "dx tool failed", you probably have to allocate more Java memory:
+- open the jvm.config file inside your Flex Air SDK directory and set at least 512 Mb
+```
+java.args=-Xmx512m
+```
+- create the _JAVA_OPTIONS system environment variable 
+```
+_JAVA_OPTIONS=-Xmx512m
+```
+
 ## FAQ
 
 Image Packs do not work on Android Builds, the only way I know to fix is this is to rewrite the code so that it embeds the image when compiling the swf, unfortunately that would mean the size of the file would increase quite considerable(100mb+) and might slow down the android version more :P

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All copyrights belong to their respective owners.
 1. Launch Flash Develop and Install Flex + Air SDK (Tools -> Install Software).
 1. Download the [source code](https://github.com/Hexxah/CoC-MOD-Android-Build/archive/master.zip)
 1. Extract
+1. Verify that the environment variable FLEX_HOME exists and contains the Flex Air SDK directory path
 1. Right Click Start.ps1 Run with Powershell
 
 #### If Run with PowerShell does not work
@@ -46,13 +47,12 @@ powershell
 Set-ExecutionPolicy unrestricted
 ```
 
-#### If build with PowerShell does not work
-If you get errors like "Error: Java heap space" or "dx tool failed", you probably have to allocate more Java memory:
-- open the jvm.config file inside your Flex Air SDK directory and set at least 512 Mb
+#### Build Errors
+- if you get "Java heap space" errors, try to allocate more java memory. Open the jvm.config file inside the %FLEX_HOME%\bin directory and update the java.args variable.
 ```
 java.args=-Xmx512m
 ```
-- create the _JAVA_OPTIONS system environment variable 
+- if you get "dx tool failed" errors, additionally create the _JAVA_OPTIONS system environment variable and allocate enough java memory.
 ```
 _JAVA_OPTIONS=-Xmx512m
 ```

--- a/Start.ps1
+++ b/Start.ps1
@@ -73,12 +73,14 @@ function BuildApk
 switch -wildcard (Read-Host "What would you like to do `n1.Download and Build Revamp `n2.Download and Build Xianxia `n3.Build from Source folder `n4.Build apk using CoC-AIR.swf `n5.Clean the Directory`n") 
 { 
     "1*" {
+		# Needed to avoid "Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel."
 		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 		$latestRelease = Invoke-WebRequest https://api.github.com/repos/Kitteh6660/Corruption-of-Champions-Mod/releases -Headers @{"Accept"="application/json"}
 		$xml='revamp.xml'
 		setup
 	}
     "2*" {
+		# Needed to avoid "Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel."
 		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 		$latestRelease = Invoke-WebRequest https://api.github.com/repos/Ormael7/Corruption-of-Champions/releases -Headers @{"Accept"="application/json"}
 		$xml = 'xianxia.xml'

--- a/Start.ps1
+++ b/Start.ps1
@@ -46,7 +46,7 @@ function Setup
 #Builds the Stuff
 function BuildSwf
 {
-	(Get-Content $xml) -replace '<versionNumber>(.*)</versionNumber>', ('<versionNumber>'+((${latestVersion}) -split "_")[-1]+'</versionNumber>')| Set-Content $xml
+	[Regex]::Replace( $(Get-Content $xml), '(?s)/<versionNumber>.*?</versionNumber>/', ('<versionNumber>'+((${latestVersion}) -split "_")[-1]+'</versionNumber>') ) | Set-Content $xml
 
 	Write-Output "Compiling/Building SWF"
 	&($fdbuild) ".\Source\Corruption-of-Champions-FD-AIR.as3proj" -version "4.6.0; 27.0" -compiler $sdk -notrace -library $library
@@ -73,11 +73,13 @@ function BuildApk
 switch -wildcard (Read-Host "What would you like to do `n1.Download and Build Revamp `n2.Download and Build Xianxia `n3.Build from Source folder `n4.Build apk using CoC-AIR.swf `n5.Clean the Directory`n") 
 { 
     "1*" {
+		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 		$latestRelease = Invoke-WebRequest https://api.github.com/repos/Kitteh6660/Corruption-of-Champions-Mod/releases -Headers @{"Accept"="application/json"}
 		$xml='revamp.xml'
 		setup
 	}
     "2*" {
+		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 		$latestRelease = Invoke-WebRequest https://api.github.com/repos/Ormael7/Corruption-of-Champions/releases -Headers @{"Accept"="application/json"}
 		$xml = 'xianxia.xml'
 		setup

--- a/Start.ps1
+++ b/Start.ps1
@@ -18,7 +18,7 @@ function Setup
 	#check url for the latest release and version number if not building from source folder
 	# The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the the version number and url.
 	$json = $latestRelease.Content | ConvertFrom-Json
-    $Script:latestVersion = $json.tag_name[0]
+	$Script:latestVersion = $json.tag_name[0]
 	$latestUrl = $json.zipball_url[0]
 	
 	Write-Output "Downloading Latest Release ..."


### PR DESCRIPTION
Hi,
when trying to build the Xianxia mod, the build failed because:
- Java memory was too low
- the xml "versionNumber" tag could not be correctly set
- github downloads fail because no secured connection could be set

I thought it would maybe interest you to include my fixes ;)
The only problem that still exists (for me) is that I have to manually set the content of "$sdk" because FLEX_HOME is undefined.

