### PR TITLE
Building from Source fix

### DIFF
--- a/Start.ps1
+++ b/Start.ps1
@@ -32,6 +32,12 @@ function Setup
 	Move-Item coc\* Source
 	Remove-Item coc,coc.zip
 	
+	BuildSwf
+}
+	
+#Builds the Stuff
+function BuildSwf
+{
 	# Edit xml to include mx swc from sdk ( otherwise gives ScrollControlBase not found error)
 	$as3project = [xml](Get-Content $project)
 	$as3project.project.libraryPaths.ChildNodes.Item(0).path = "lib\bin"
@@ -40,12 +46,6 @@ function Setup
 	$as3project.project.output.ChildNodes.Item(7).minorVersion = "0"
 	$as3project.Save((Resolve-Path $project))
 	
-	BuildSwf
-}
-	
-#Builds the Stuff
-function BuildSwf
-{
 	[Regex]::Replace( $(Get-Content $xml), '(?s)/<versionNumber>.*?</versionNumber>/', ('<versionNumber>'+((${latestVersion}) -split "_")[-1]+'</versionNumber>') ) | Set-Content $xml
 
 	Write-Output "Compiling/Building SWF"


### PR DESCRIPTION
Building from Source would fail without the addition of the frameworks\libs\mx piece due to the ScrollControlBase not found error.  By moving it to inside BuildSwf, this guarantees that that edit will be made regardless of code source (online or local).